### PR TITLE
Ads some "QOL improvements" to the the translation tool + few bug fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ src/data/app/config.json
 src/data/user
 src/data/translator
 src/data/logs
+src/SSE-AT Output
 tests
 SSE-AT
 .vscode

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,4 @@ websocket-client
 unrar
 googletrans==3.1.0a0
 deepl
+zmq

--- a/src/translation_editor/editor_tab.py
+++ b/src/translation_editor/editor_tab.py
@@ -283,7 +283,6 @@ class EditorTab(qtw.QWidget):
             lambda: self.set_status(utils.String.Status.TranslationRequired)
         )
 
-
         def on_context_menu(point: qtc.QPoint):
             if not self.strings_widget.selectedItems():
                 return
@@ -506,9 +505,15 @@ class EditorTab(qtw.QWidget):
 
         while currentIndex < self.strings_widget.topLevelItemCount():
             nextItem = self.strings_widget.topLevelItem(currentIndex)
-            string = next((_string for _string in self.strings if _string.tree_item == nextItem), None)
+            string = next(
+                (_string for _string in self.strings if _string.tree_item == nextItem),
+                None,
+            )
 
-            if string is not None and string.status != string.Status.TranslationComplete:
+            if (
+                string is not None
+                and string.status != string.Status.TranslationComplete
+            ):
                 from .translator_dialog import TranslatorDialog
 
                 dialog = TranslatorDialog(self, string)
@@ -516,9 +521,8 @@ class EditorTab(qtw.QWidget):
                 dialog.string_entry.setFocus()
                 self.current_translation_index = currentIndex
                 break
-            
+
             currentIndex += 1
-                
 
     def open_translator_dialog(self, item: qtw.QTreeWidgetItem, column: int):
         """
@@ -534,7 +538,6 @@ class EditorTab(qtw.QWidget):
         dialog.show()
         dialog.string_entry.setFocus()
 
-
     def update_matching_strings(self, original, translation, status):
         """
         Update strings that are matching
@@ -543,7 +546,9 @@ class EditorTab(qtw.QWidget):
             if string.original_string == original:
                 if string.status != string.Status.TranslationComplete:
                     string.translated_string = str(translation)
-                    string.tree_item.setText(4, utils.trim_string(string.translated_string))
+                    string.tree_item.setText(
+                        4, utils.trim_string(string.translated_string)
+                    )
                     string.status = status
 
         self.update_string_list()
@@ -967,14 +972,13 @@ class EditorTab(qtw.QWidget):
 
     def set_status(self, status: utils.String.Status):
         for item in self.strings_widget.selectedItems():
-            string = [
-                _string for _string in self.strings if _string.tree_item == item
-            ][0]
+            string = [_string for _string in self.strings if _string.tree_item == item][
+                0
+            ]
             string.status = status
 
         self.update_string_list()
         self.changes_signal.emit()
-
 
     def copy_selected(self):
         """

--- a/src/translation_editor/translator_dialog.py
+++ b/src/translation_editor/translator_dialog.py
@@ -112,15 +112,26 @@ class TranslatorDialog(qtw.QWidget):
 
         hlayout.addStretch()
 
-
         next_complete_shortcut = qtg.QShortcut(qtg.QKeySequence("F1"), self)
-        next_complete_shortcut.activated.connect(lambda: self.finish(proceed_to_next=True, status=utils.String.Status.TranslationComplete))
+        next_complete_shortcut.activated.connect(
+            lambda: self.finish(
+                proceed_to_next=True, status=utils.String.Status.TranslationComplete
+            )
+        )
 
         next_incomplete_shortcut = qtg.QShortcut(qtg.QKeySequence("F2"), self)
-        next_incomplete_shortcut.activated.connect(lambda: self.finish(proceed_to_next=True, status=utils.String.Status.TranslationIncomplete))
+        next_incomplete_shortcut.activated.connect(
+            lambda: self.finish(
+                proceed_to_next=True, status=utils.String.Status.TranslationIncomplete
+            )
+        )
 
         next_required_shortcut = qtg.QShortcut(qtg.QKeySequence("F3"), self)
-        next_required_shortcut.activated.connect(lambda: self.finish(proceed_to_next=True, status=utils.String.Status.TranslationRequired))
+        next_required_shortcut.activated.connect(
+            lambda: self.finish(
+                proceed_to_next=True, status=utils.String.Status.TranslationRequired
+            )
+        )
 
         finish_button = qtw.QPushButton(self.loc.main.done + " (Ctrl+Enter)")
         finish_button.clicked.connect(lambda: self.finish())
@@ -166,8 +177,10 @@ class TranslatorDialog(qtw.QWidget):
                 return
 
         event.accept()
-                
-    def finish(self, proceed_to_next=False, status=utils.String.Status.TranslationComplete):
+
+    def finish(
+        self, proceed_to_next=False, status=utils.String.Status.TranslationComplete
+    ):
         """
         Saves edited string and marks as "Translation Complete" and closes dialog.
         """
@@ -175,15 +188,19 @@ class TranslatorDialog(qtw.QWidget):
 
         if self.string.translated_string != self.string_entry.toPlainText():
             self.string.translated_string = self.string_entry.toPlainText()
-        
+
             if self.string.translated_string != self.string.original_string:
                 self.string.tree_item.setText(
                     4, utils.trim_string(self.string.translated_string)
                 )
-            
+
             self.changes_pending = False
 
-        self.tab.update_matching_strings(self.string.original_string, utils.trim_string(self.string.translated_string), status)
+        self.tab.update_matching_strings(
+            self.string.original_string,
+            utils.trim_string(self.string.translated_string),
+            status,
+        )
         self.tab.update_string_list()
         self.tab.changes_signal.emit()
 

--- a/src/translation_editor/translator_dialog.py
+++ b/src/translation_editor/translator_dialog.py
@@ -86,6 +86,7 @@ class TranslatorDialog(qtw.QWidget):
         translate_button = qtw.QPushButton(self.mloc.translate_with_api)
         translate_button.setIcon(qta.icon("ri.translate", color="#ffffff"))
         translate_button.clicked.connect(self.translate_with_api)
+        translate_button.setShortcut(qtg.QKeySequence("F4"))
         hlayout.addWidget(translate_button)
 
         splitter = qtw.QSplitter()
@@ -111,8 +112,18 @@ class TranslatorDialog(qtw.QWidget):
 
         hlayout.addStretch()
 
+
+        next_complete_shortcut = qtg.QShortcut(qtg.QKeySequence("F1"), self)
+        next_complete_shortcut.activated.connect(lambda: self.finish(proceed_to_next=True, status=utils.String.Status.TranslationComplete))
+
+        next_incomplete_shortcut = qtg.QShortcut(qtg.QKeySequence("F2"), self)
+        next_incomplete_shortcut.activated.connect(lambda: self.finish(proceed_to_next=True, status=utils.String.Status.TranslationIncomplete))
+
+        next_required_shortcut = qtg.QShortcut(qtg.QKeySequence("F3"), self)
+        next_required_shortcut.activated.connect(lambda: self.finish(proceed_to_next=True, status=utils.String.Status.TranslationRequired))
+
         finish_button = qtw.QPushButton(self.loc.main.done + " (Ctrl+Enter)")
-        finish_button.clicked.connect(self.finish)
+        finish_button.clicked.connect(lambda: self.finish())
         finish_button.setShortcut(qtg.QKeySequence("Ctrl+Return"))
         finish_button.setObjectName("accent_button")
         hlayout.addWidget(finish_button)
@@ -155,20 +166,28 @@ class TranslatorDialog(qtw.QWidget):
                 return
 
         event.accept()
-
-    def finish(self):
+                
+    def finish(self, proceed_to_next=False, status=utils.String.Status.TranslationComplete):
         """
         Saves edited string and marks as "Translation Complete" and closes dialog.
         """
+        self.string.status = status
 
-        self.string.translated_string = self.string_entry.toPlainText()
-        self.string.status = utils.String.Status.TranslationComplete
-        self.string.tree_item.setText(
-            4, utils.trim_string(self.string.translated_string)
-        )
-        self.changes_pending = False
+        if self.string.translated_string != self.string_entry.toPlainText():
+            self.string.translated_string = self.string_entry.toPlainText()
+        
+            if self.string.translated_string != self.string.original_string:
+                self.string.tree_item.setText(
+                    4, utils.trim_string(self.string.translated_string)
+                )
+            
+            self.changes_pending = False
 
+        self.tab.update_matching_strings(self.string.original_string, utils.trim_string(self.string.translated_string), status)
         self.tab.update_string_list()
         self.tab.changes_signal.emit()
+
+        if proceed_to_next:
+            self.tab.next_signal.emit()
 
         self.close()


### PR DESCRIPTION
**Ads some "QOL improvements" to the translation feature of SSE :**

- Validate strings automatically when they have the same original text
- Switch to the next string & change the state of the string from the translation dialog with the keyboard (same feature as Xtranslator) with F1 (complete), F2 (incomplete) and F3 (needs to be translated)
- Added a shortcut (F4) for Google Translate in the translation dialog
- Added a few keyboards shortcuts to change the states of the translation with the keyboard

+ Fixed a missing dependency in requirements.txt & added the output folder to gitignore