### PR TITLE
Downloader: Fix non-premium NM downloads blocking entire queue when CDT is enabled

### DIFF
--- a/src/core/downloader/worker.py
+++ b/src/core/downloader/worker.py
@@ -103,7 +103,7 @@ class Worker(QThread):
 
         self.log.info(f"Processing download '{file_name}'...")
 
-        if self.provider.direct_downloads_possible():
+        if self.provider.direct_downloads_possible(download.source):
             self.log.info("Downloading translation...")
             progress_callback(
                 ProgressUpdate(0, 0, self.tr("Downloading translation..."))

--- a/src/core/translation_provider/provider.py
+++ b/src/core/translation_provider/provider.py
@@ -29,15 +29,24 @@ class Provider:
     def __init__(self, user_config: UserConfig) -> None:
         ProviderManager.init(user_config)
 
-    def direct_downloads_possible(self) -> bool:
+    def direct_downloads_possible(self, source: Optional[Source] = None) -> bool:
         """
         Checks if direct downloads are possible for Nexus Mods API.
+
+        Args:
+            source (Optional[Source], optional): Source. Defaults to preferred.
 
         Returns:
             bool: `True` if direct downloads are possible, `False` otherwise
         """
 
-        return ProviderManager.get_default_provider().is_direct_download_possible()
+        if source is None:
+            return ProviderManager.get_default_provider().is_direct_download_possible()
+
+        else:
+            return ProviderManager.get_provider_by_source(
+                source
+            ).is_direct_download_possible()
 
     def get_remaining_requests(self) -> tuple[int, int]:
         """


### PR DESCRIPTION
Resolves #91 