### PR TITLE
Add automated Nexus Mods publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,18 +19,19 @@ jobs:
 
     steps:
       - name: Check out source and submodules
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0
           submodules: recursive
+          persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.14"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@d0d8abe699bfb85fec6de9f7adb5ae17292296ff # v6
         with:
           enable-cache: true
 
@@ -133,24 +134,51 @@ jobs:
       - name: Update update.json on master
         shell: pwsh
         env:
+          GH_TOKEN: ${{ github.token }}
           RELEASE_TAG: ${{ steps.metadata.outputs.tag }}
           DOWNLOAD_URL: ${{ steps.nexus_after.outputs.download_url }}
         run: |
-          git fetch origin master
-          git switch --force-create master origin/master
+          $auth = [Convert]::ToBase64String(
+            [Text.Encoding]::UTF8.GetBytes("x-access-token:$env:GH_TOKEN")
+          )
 
-          python scripts/release_workflow.py update-json `
-            --version $env:RELEASE_TAG `
-            --download-url $env:DOWNLOAD_URL
+          for ($attempt = 1; $attempt -le 5; $attempt++) {
+            git fetch origin master
+            if ($LASTEXITCODE -ne 0) {
+              throw "Failed to fetch master."
+            }
+            git switch --force-create master origin/master
+            if ($LASTEXITCODE -ne 0) {
+              throw "Failed to check out origin/master."
+            }
 
-          git add -- update.json
-          git diff --cached --quiet
-          if ($LASTEXITCODE -eq 0) {
-            Write-Host "update.json already contains the published release."
-            exit 0
+            python scripts/release_workflow.py update-json `
+              --version $env:RELEASE_TAG `
+              --download-url $env:DOWNLOAD_URL
+            if ($LASTEXITCODE -ne 0) {
+              throw "Failed to generate update.json."
+            }
+
+            git add -- update.json
+            git diff --cached --quiet
+            if ($LASTEXITCODE -eq 0) {
+              Write-Host "update.json already contains this or a newer release."
+              exit 0
+            }
+
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git commit -m "chore(release): update metadata for $env:RELEASE_TAG"
+            if ($LASTEXITCODE -ne 0) {
+              throw "Failed to commit update.json."
+            }
+            git -c "http.https://github.com/.extraheader=AUTHORIZATION: basic $auth" `
+              push origin HEAD:master
+            if ($LASTEXITCODE -eq 0) {
+              exit 0
+            }
+
+            Write-Warning "Push raced with another release; retrying ($attempt/5)."
           }
 
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git commit -m "chore(release): update metadata for $env:RELEASE_TAG"
-          git push origin HEAD:master
+          throw "Failed to update update.json after 5 attempts."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,156 @@
+name: Publish release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  release:
+    runs-on: windows-latest
+    timeout-minutes: 90
+
+    steps:
+      - name: Check out source and submodules
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: recursive
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.14"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+
+      - name: Validate tag and prepare release metadata
+        id: metadata
+        shell: pwsh
+        run: |
+          python scripts/release_workflow.py prepare `
+            --tag $env:GITHUB_REF_NAME `
+            --changes-file "$env:RUNNER_TEMP/changes.md" `
+            --github-output $env:GITHUB_OUTPUT
+
+      - name: Install locked dependencies
+        run: uv sync --locked
+
+      - name: Build release archive
+        shell: cmd
+        run: build.bat
+
+      - name: Verify release archive
+        shell: pwsh
+        run: |
+          if (-not (Test-Path -LiteralPath '${{ steps.metadata.outputs.archive_path }}' -PathType Leaf)) {
+            throw "Expected release archive was not created: ${{ steps.metadata.outputs.archive_path }}"
+          }
+
+      - name: Resolve existing Nexus Mods file
+        id: nexus_before
+        shell: pwsh
+        env:
+          NEXUSMODS_API_KEY: ${{ secrets.NEXUSMODS_API_KEY }}
+        run: |
+          python scripts/release_workflow.py resolve `
+            --game-domain '${{ steps.metadata.outputs.game_domain }}' `
+            --public-mod-id '${{ steps.metadata.outputs.public_mod_id }}' `
+            --file-name '${{ steps.metadata.outputs.description }}' `
+            --target-version '${{ steps.metadata.outputs.tag }}' `
+            --github-output $env:GITHUB_OUTPUT
+
+      - name: Upload release to Nexus Mods
+        if: steps.nexus_before.outputs.already_published != 'true'
+        uses: Nexus-Mods/upload-action@19da5c91527877cd0bfedc6e6239c911035846a0
+        with:
+          api_key: ${{ secrets.NEXUSMODS_API_KEY }}
+          file_id: ${{ steps.nexus_before.outputs.file_id }}
+          filename: ${{ steps.metadata.outputs.archive_path }}
+          version: ${{ steps.metadata.outputs.tag }}
+          display_name: ${{ steps.metadata.outputs.description }} ${{ steps.metadata.outputs.tag }}
+          description: 'Please read the [url=https://docs.moddingforge.com/sse-at/quick_start.html]instructions[/url]![url=https://github.com/Cutleast/SSE-Auto-Translator/blob/master/Changelog.md]Changelog[/url]'
+          category: main
+          allow_mod_manager_download: true
+          show_requirements_pop_up: false
+          update_mod_version: true
+          archive_existing_version: false
+
+      - name: Verify Nexus Mods release
+        id: nexus_after
+        shell: pwsh
+        env:
+          NEXUSMODS_API_KEY: ${{ secrets.NEXUSMODS_API_KEY }}
+        run: |
+          python scripts/release_workflow.py verify `
+            --game-domain '${{ steps.metadata.outputs.game_domain }}' `
+            --public-mod-id '${{ steps.metadata.outputs.public_mod_id }}' `
+            --file-name '${{ steps.metadata.outputs.description }}' `
+            --file-id '${{ steps.nexus_before.outputs.file_id }}' `
+            --target-version '${{ steps.metadata.outputs.tag }}' `
+            --nexus-url '${{ steps.metadata.outputs.nexus_url }}' `
+            --github-output $env:GITHUB_OUTPUT
+
+      - name: Create release notes
+        shell: pwsh
+        run: |
+          python scripts/release_workflow.py notes `
+            --changes-file '${{ steps.metadata.outputs.changes_file }}' `
+            --download-url '${{ steps.nexus_after.outputs.download_url }}' `
+            --notes-file "$env:RUNNER_TEMP/release-notes.md"
+
+      - name: Create GitHub Release without assets
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ steps.metadata.outputs.tag }}
+        run: |
+          gh release view $env:RELEASE_TAG *> $null
+          if ($LASTEXITCODE -eq 0) {
+            gh release edit $env:RELEASE_TAG `
+              --title $env:RELEASE_TAG `
+              --notes-file "$env:RUNNER_TEMP/release-notes.md"
+          } else {
+            gh release create $env:RELEASE_TAG `
+              --verify-tag `
+              --title $env:RELEASE_TAG `
+              --notes-file "$env:RUNNER_TEMP/release-notes.md"
+          }
+          if ($LASTEXITCODE -ne 0) {
+            throw "Failed to create or update GitHub Release $env:RELEASE_TAG."
+          }
+
+      - name: Update update.json on master
+        shell: pwsh
+        env:
+          RELEASE_TAG: ${{ steps.metadata.outputs.tag }}
+          DOWNLOAD_URL: ${{ steps.nexus_after.outputs.download_url }}
+        run: |
+          git fetch origin master
+          git switch --force-create master origin/master
+
+          python scripts/release_workflow.py update-json `
+            --version $env:RELEASE_TAG `
+            --download-url $env:DOWNLOAD_URL
+
+          git add -- update.json
+          git diff --cached --quiet
+          if ($LASTEXITCODE -eq 0) {
+            Write-Host "update.json already contains the published release."
+            exit 0
+          }
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git commit -m "chore(release): update metadata for $env:RELEASE_TAG"
+          git push origin HEAD:master

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,9 @@ dependencies = [
     "websocket-client",
 ]
 
+[project.urls]
+"Nexus Mods" = "https://www.nexusmods.com/skyrimspecialedition/mods/111491"
+
 [dependency-groups]
 dev = [
     "nuitka",
@@ -82,7 +85,7 @@ convention = "google"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
-pythonpath = ["src"]
+pythonpath = ["src", "."]
 log_cli = true
 log_cli_level = "DEBUG"
 log_cli_format = "[%(asctime)s.%(msecs)03d][%(levelname)s][%(name)s.%(funcName)s]: %(message)s"

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,1 @@
+"""Project maintenance and release scripts."""

--- a/scripts/release_workflow.py
+++ b/scripts/release_workflow.py
@@ -28,6 +28,10 @@ class ReleaseError(RuntimeError):
     """Raised when release metadata or Nexus state is invalid."""
 
 
+class RetryableReleaseError(ReleaseError):
+    """Raised for temporary Nexus failures that may succeed on retry."""
+
+
 @dataclass(frozen=True)
 class ProjectMetadata:
     """Metadata required by the release workflow."""
@@ -63,6 +67,16 @@ def normalize_version(version: str) -> str:
     """Normalize Nexus and Git version strings for comparison."""
 
     return version.strip().removeprefix("v")
+
+
+def version_key(version: str) -> tuple[int, ...]:
+    """Convert the project's numeric version format into a comparison key."""
+
+    normalized = normalize_version(version)
+    parts = normalized.split(".")
+    if not parts or any(not part.isdecimal() for part in parts):
+        raise ReleaseError(f"Unsupported release version '{version}'.")
+    return tuple(int(part) for part in parts)
 
 
 def load_project_metadata(project_file: Path, tag: str) -> ProjectMetadata:
@@ -123,11 +137,20 @@ def create_release_notes(changes: str, download_url: str) -> str:
     return f"## Changes\n\n{changes}\n\n## Download\n\n[{download_url}]({download_url})\n"
 
 
-def update_update_json(update_file: Path, version: str, download_url: str) -> None:
+def update_update_json(update_file: Path, version: str, download_url: str) -> bool:
     """Update the application's remote update metadata."""
+
+    if update_file.is_file():
+        current = json.loads(update_file.read_text(encoding="utf8"))
+        current_version = current.get("version")
+        if isinstance(current_version, str) and version_key(
+            current_version
+        ) > version_key(version):
+            return False
 
     data = {"version": normalize_version(version), "download_url": download_url}
     update_file.write_text(json.dumps(data, indent=4) + "\n", encoding="utf8")
+    return True
 
 
 def write_github_outputs(output_file: Path, values: dict[str, str]) -> None:
@@ -164,11 +187,18 @@ class NexusClient:
                 result = json.load(response)
         except urllib.error.HTTPError as error:
             detail = error.read().decode("utf8", errors="replace")[:500]
-            raise ReleaseError(
+            error_type = (
+                RetryableReleaseError
+                if error.code == 429 or 500 <= error.code < 600
+                else ReleaseError
+            )
+            raise error_type(
                 f"Nexus API returned HTTP {error.code} for {url}: {detail}"
             ) from error
         except urllib.error.URLError as error:
-            raise ReleaseError(f"Nexus API request failed for {url}: {error.reason}") from error
+            raise RetryableReleaseError(
+                f"Nexus API request failed for {url}: {error.reason}"
+            ) from error
 
         if not isinstance(result, dict):
             raise ReleaseError(f"Nexus API returned an invalid response for {url}.")
@@ -324,18 +354,19 @@ def command_resolve(args: argparse.Namespace) -> None:
     state = client.inspect_release(
         args.game_domain, args.public_mod_id, args.file_name
     )
+    file_matches_target = normalize_version(state.file.version) == normalize_version(
+        args.target_version
+    )
     versions_match = normalize_version(state.mod_version) == normalize_version(
         state.file.version
     )
-    if not versions_match:
+    if not versions_match and not file_matches_target:
         raise ReleaseError(
             f"Nexus mod-page version '{state.mod_version}' does not match latest "
             f"file version '{state.file.version}'."
         )
 
-    already_published = normalize_version(state.mod_version) == normalize_version(
-        args.target_version
-    )
+    already_published = file_matches_target
     write_github_outputs(
         args.github_output,
         {
@@ -353,13 +384,19 @@ def command_verify(args: argparse.Namespace) -> None:
     client = NexusClient(os.environ.get("NEXUSMODS_API_KEY", ""))
     deadline = time.monotonic() + args.timeout
     last_state: NexusReleaseState | None = None
+    last_retryable_error: RetryableReleaseError | None = None
     while time.monotonic() < deadline:
-        last_state = client.inspect_release(
-            args.game_domain,
-            args.public_mod_id,
-            args.file_name,
-            file_id=args.file_id,
-        )
+        try:
+            last_state = client.inspect_release(
+                args.game_domain,
+                args.public_mod_id,
+                args.file_name,
+                file_id=args.file_id,
+            )
+        except RetryableReleaseError as error:
+            last_retryable_error = error
+            time.sleep(args.interval)
+            continue
         if (
             normalize_version(last_state.mod_version)
             == normalize_version(args.target_version)
@@ -379,7 +416,12 @@ def command_verify(args: argparse.Namespace) -> None:
         time.sleep(args.interval)
 
     if last_state is None:
-        raise ReleaseError("Timed out before Nexus returned release state.")
+        detail = (
+            f" Last transient error: {last_retryable_error}."
+            if last_retryable_error
+            else ""
+        )
+        raise ReleaseError(f"Timed out before Nexus returned release state.{detail}")
     raise ReleaseError(
         f"Timed out waiting for Nexus version '{args.target_version}'. "
         f"Mod page: '{last_state.mod_version}', file: '{last_state.file.version}'."

--- a/scripts/release_workflow.py
+++ b/scripts/release_workflow.py
@@ -1,0 +1,464 @@
+"""Utilities used by the tag release workflow."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import time
+import tomllib
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from decimal import Decimal, InvalidOperation
+from pathlib import Path
+from typing import Any
+
+NEXUS_URL_PATTERN = re.compile(
+    r"^https://www\.nexusmods\.com/(?P<game>[a-z0-9-]+)/mods/(?P<mod_id>\d+)/?$"
+)
+NEXUS_V3_BASE_URL = "https://api.nexusmods.com/v3"
+NEXUS_V1_BASE_URL = "https://api.nexusmods.com/v1"
+USER_AGENT = "SSE-Auto-Translator release workflow"
+
+
+class ReleaseError(RuntimeError):
+    """Raised when release metadata or Nexus state is invalid."""
+
+
+@dataclass(frozen=True)
+class ProjectMetadata:
+    """Metadata required by the release workflow."""
+
+    version: str
+    tag: str
+    description: str
+    nexus_url: str
+    game_domain: str
+    public_mod_id: str
+    archive_path: Path
+
+
+@dataclass(frozen=True)
+class NexusFileState:
+    """Relevant state of an existing Nexus mod file."""
+
+    file_id: str
+    name: str
+    version: str
+    public_version_id: str
+
+
+@dataclass(frozen=True)
+class NexusReleaseState:
+    """Current Nexus mod-page and file state."""
+
+    mod_version: str
+    file: NexusFileState
+
+
+def normalize_version(version: str) -> str:
+    """Normalize Nexus and Git version strings for comparison."""
+
+    return version.strip().removeprefix("v")
+
+
+def load_project_metadata(project_file: Path, tag: str) -> ProjectMetadata:
+    """Load project data and validate that the tag matches its version."""
+
+    project = tomllib.loads(project_file.read_text(encoding="utf8"))["project"]
+    version = str(project["version"])
+    expected_tag = f"v{version}"
+    if tag != expected_tag:
+        raise ReleaseError(
+            f"Tag '{tag}' does not match project version '{version}' "
+            f"(expected '{expected_tag}')."
+        )
+
+    description = str(project["description"])
+    try:
+        nexus_url = str(project["urls"]["Nexus Mods"])
+    except KeyError as error:
+        raise ReleaseError(
+            "pyproject.toml is missing project.urls.'Nexus Mods'."
+        ) from error
+
+    url_match = NEXUS_URL_PATTERN.fullmatch(nexus_url)
+    if url_match is None:
+        raise ReleaseError(f"Unsupported Nexus Mods project URL: {nexus_url}")
+
+    return ProjectMetadata(
+        version=version,
+        tag=tag,
+        description=description,
+        nexus_url=nexus_url,
+        game_domain=url_match.group("game"),
+        public_mod_id=url_match.group("mod_id"),
+        archive_path=Path("dist") / f"{description}_v{version}.zip",
+    )
+
+
+def extract_changelog(changelog_file: Path, tag: str) -> str:
+    """Extract the body of a version section from the changelog."""
+
+    changelog = changelog_file.read_text(encoding="utf8")
+    heading = re.compile(rf"^#\s+{re.escape(tag)}(?:\s+.*)?$", re.MULTILINE)
+    match = heading.search(changelog)
+    if match is None:
+        raise ReleaseError(f"No changelog section found for '{tag}'.")
+
+    next_heading = re.search(r"^#\s+v\S+.*$", changelog[match.end() :], re.MULTILINE)
+    end = match.end() + next_heading.start() if next_heading else len(changelog)
+    changes = changelog[match.end() : end].strip()
+    if not changes:
+        raise ReleaseError(f"Changelog section for '{tag}' is empty.")
+    return changes
+
+
+def create_release_notes(changes: str, download_url: str) -> str:
+    """Create the GitHub Release body."""
+
+    return f"## Changes\n\n{changes}\n\n## Download\n\n[{download_url}]({download_url})\n"
+
+
+def update_update_json(update_file: Path, version: str, download_url: str) -> None:
+    """Update the application's remote update metadata."""
+
+    data = {"version": normalize_version(version), "download_url": download_url}
+    update_file.write_text(json.dumps(data, indent=4) + "\n", encoding="utf8")
+
+
+def write_github_outputs(output_file: Path, values: dict[str, str]) -> None:
+    """Append simple values to a GitHub Actions output file."""
+
+    with output_file.open("a", encoding="utf8") as stream:
+        for key, value in values.items():
+            if "\n" in value or "\r" in value:
+                raise ReleaseError(f"GitHub output '{key}' contains a newline.")
+            stream.write(f"{key}={value}\n")
+
+
+class NexusClient:
+    """Small read-only client for resolving and verifying Nexus releases."""
+
+    def __init__(self, api_key: str) -> None:
+        """Create a client using an API key that remains in memory only."""
+
+        if not api_key:
+            raise ReleaseError("NEXUSMODS_API_KEY is not configured.")
+        self.__api_key = api_key
+
+    def __get_json(self, url: str) -> dict[str, Any]:
+        request = urllib.request.Request(
+            url,
+            headers={
+                "apikey": self.__api_key,
+                "Accept": "application/json",
+                "User-Agent": USER_AGENT,
+            },
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=30) as response:
+                result = json.load(response)
+        except urllib.error.HTTPError as error:
+            detail = error.read().decode("utf8", errors="replace")[:500]
+            raise ReleaseError(
+                f"Nexus API returned HTTP {error.code} for {url}: {detail}"
+            ) from error
+        except urllib.error.URLError as error:
+            raise ReleaseError(f"Nexus API request failed for {url}: {error.reason}") from error
+
+        if not isinstance(result, dict):
+            raise ReleaseError(f"Nexus API returned an invalid response for {url}.")
+        return result
+
+    def get_mod_version(self, game_domain: str, public_mod_id: str) -> str:
+        """Get the version currently displayed on the Nexus mod page."""
+
+        response = self.__get_json(
+            f"{NEXUS_V1_BASE_URL}/games/{game_domain}/mods/{public_mod_id}.json"
+        )
+        version = response.get("version")
+        if not isinstance(version, str) or not version.strip():
+            raise ReleaseError("Nexus mod response does not contain a version.")
+        return version
+
+    def get_internal_mod_id(self, game_domain: str, public_mod_id: str) -> str:
+        """Resolve a game-scoped mod ID to the v3 internal ID."""
+
+        response = self.__get_json(
+            f"{NEXUS_V3_BASE_URL}/games/{game_domain}/mods/{public_mod_id}"
+        )
+        internal_id = response.get("data", {}).get("id")
+        if not isinstance(internal_id, (str, int)) or str(internal_id) == "":
+            raise ReleaseError("Nexus mod response does not contain an internal ID.")
+        return str(internal_id)
+
+    def get_mod_files(self, internal_mod_id: str) -> list[dict[str, Any]]:
+        """Get all mod files belonging to a Nexus mod."""
+
+        response = self.__get_json(
+            f"{NEXUS_V3_BASE_URL}/mods/{internal_mod_id}/files"
+        )
+        files = response.get("data", {}).get("mod_files")
+        if not isinstance(files, list):
+            raise ReleaseError("Nexus files response does not contain a file list.")
+        return [file for file in files if isinstance(file, dict)]
+
+    def get_file_versions(self, file_id: str) -> list[dict[str, Any]]:
+        """Get all published versions of a Nexus mod file."""
+
+        response = self.__get_json(
+            f"{NEXUS_V3_BASE_URL}/mod-files/{file_id}/versions"
+        )
+        versions = response.get("data", {}).get("versions")
+        if not isinstance(versions, list):
+            raise ReleaseError("Nexus versions response does not contain a version list.")
+        return [version for version in versions if isinstance(version, dict)]
+
+    @staticmethod
+    def latest_version(versions: list[dict[str, Any]]) -> dict[str, Any]:
+        """Select the newest version using its position in the update chain."""
+
+        if not versions:
+            raise ReleaseError("Nexus mod file has no versions.")
+
+        def position(version: dict[str, Any]) -> Decimal:
+            try:
+                return Decimal(str(version["position"]))
+            except (KeyError, InvalidOperation) as error:
+                raise ReleaseError("Nexus file version has an invalid position.") from error
+
+        return max(versions, key=position)
+
+    def inspect_release(
+        self,
+        game_domain: str,
+        public_mod_id: str,
+        expected_file_name: str,
+        file_id: str | None = None,
+    ) -> NexusReleaseState:
+        """Read and validate the current mod-page and target-file state."""
+
+        mod_version = self.get_mod_version(game_domain, public_mod_id)
+        internal_mod_id = self.get_internal_mod_id(game_domain, public_mod_id)
+        files = self.get_mod_files(internal_mod_id)
+        candidates = [
+            file
+            for file in files
+            if file.get("is_active") is True
+            and file.get("name") == expected_file_name
+            and (file_id is None or str(file.get("id")) == file_id)
+        ]
+        if len(candidates) != 1:
+            summary = [
+                {
+                    "id": file.get("id"),
+                    "name": file.get("name"),
+                    "is_active": file.get("is_active"),
+                }
+                for file in files
+            ]
+            raise ReleaseError(
+                f"Expected exactly one active Nexus file named "
+                f"'{expected_file_name}', found {len(candidates)}. Files: {summary}"
+            )
+
+        candidate = candidates[0]
+        resolved_file_id = str(candidate["id"])
+        latest = self.latest_version(self.get_file_versions(resolved_file_id))
+        version = latest.get("version")
+        public_version_id = latest.get("game_scoped_id")
+        if not isinstance(version, str) or not version:
+            raise ReleaseError("Latest Nexus file version has no version string.")
+        if (
+            not isinstance(public_version_id, (str, int))
+            or str(public_version_id) == ""
+        ):
+            raise ReleaseError("Latest Nexus file version has no public file ID.")
+
+        return NexusReleaseState(
+            mod_version=mod_version,
+            file=NexusFileState(
+                file_id=resolved_file_id,
+                name=expected_file_name,
+                version=version,
+                public_version_id=str(public_version_id),
+            ),
+        )
+
+
+def direct_download_url(nexus_url: str, public_file_id: str) -> str:
+    """Build a public Nexus file-tab link."""
+
+    return f"{nexus_url}?tab=files&file_id={public_file_id}"
+
+
+def command_prepare(args: argparse.Namespace) -> None:
+    """Validate project metadata and prepare changelog outputs."""
+
+    metadata = load_project_metadata(args.project_file, args.tag)
+    changes = extract_changelog(args.changelog_file, metadata.tag)
+    args.changes_file.write_text(changes + "\n", encoding="utf8")
+    write_github_outputs(
+        args.github_output,
+        {
+            "version": metadata.version,
+            "tag": metadata.tag,
+            "description": metadata.description,
+            "nexus_url": metadata.nexus_url,
+            "game_domain": metadata.game_domain,
+            "public_mod_id": metadata.public_mod_id,
+            "archive_path": str(metadata.archive_path),
+            "changes_file": str(args.changes_file),
+        },
+    )
+
+
+def command_resolve(args: argparse.Namespace) -> None:
+    """Resolve the existing Nexus file and determine rerun state."""
+
+    client = NexusClient(os.environ.get("NEXUSMODS_API_KEY", ""))
+    state = client.inspect_release(
+        args.game_domain, args.public_mod_id, args.file_name
+    )
+    versions_match = normalize_version(state.mod_version) == normalize_version(
+        state.file.version
+    )
+    if not versions_match:
+        raise ReleaseError(
+            f"Nexus mod-page version '{state.mod_version}' does not match latest "
+            f"file version '{state.file.version}'."
+        )
+
+    already_published = normalize_version(state.mod_version) == normalize_version(
+        args.target_version
+    )
+    write_github_outputs(
+        args.github_output,
+        {
+            "file_id": state.file.file_id,
+            "already_published": str(already_published).lower(),
+            "current_version": state.mod_version,
+            "public_file_id": state.file.public_version_id,
+        },
+    )
+
+
+def command_verify(args: argparse.Namespace) -> None:
+    """Wait until Nexus exposes the newly published version."""
+
+    client = NexusClient(os.environ.get("NEXUSMODS_API_KEY", ""))
+    deadline = time.monotonic() + args.timeout
+    last_state: NexusReleaseState | None = None
+    while time.monotonic() < deadline:
+        last_state = client.inspect_release(
+            args.game_domain,
+            args.public_mod_id,
+            args.file_name,
+            file_id=args.file_id,
+        )
+        if (
+            normalize_version(last_state.mod_version)
+            == normalize_version(args.target_version)
+            == normalize_version(last_state.file.version)
+        ):
+            download_url = direct_download_url(
+                args.nexus_url, last_state.file.public_version_id
+            )
+            write_github_outputs(
+                args.github_output,
+                {
+                    "public_file_id": last_state.file.public_version_id,
+                    "download_url": download_url,
+                },
+            )
+            return
+        time.sleep(args.interval)
+
+    if last_state is None:
+        raise ReleaseError("Timed out before Nexus returned release state.")
+    raise ReleaseError(
+        f"Timed out waiting for Nexus version '{args.target_version}'. "
+        f"Mod page: '{last_state.mod_version}', file: '{last_state.file.version}'."
+    )
+
+
+def command_notes(args: argparse.Namespace) -> None:
+    """Create GitHub Release notes containing the direct Nexus link."""
+
+    changes = args.changes_file.read_text(encoding="utf8").strip()
+    args.notes_file.write_text(
+        create_release_notes(changes, args.download_url), encoding="utf8"
+    )
+
+
+def command_update_json(args: argparse.Namespace) -> None:
+    """Write application update metadata after publishing."""
+
+    update_update_json(args.update_file, args.version, args.download_url)
+
+
+def create_parser() -> argparse.ArgumentParser:
+    """Create the command-line parser."""
+
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(required=True)
+
+    prepare = subparsers.add_parser("prepare")
+    prepare.add_argument("--tag", required=True)
+    prepare.add_argument("--project-file", type=Path, default=Path("pyproject.toml"))
+    prepare.add_argument("--changelog-file", type=Path, default=Path("Changelog.md"))
+    prepare.add_argument("--changes-file", type=Path, required=True)
+    prepare.add_argument("--github-output", type=Path, required=True)
+    prepare.set_defaults(handler=command_prepare)
+
+    resolve = subparsers.add_parser("resolve")
+    resolve.add_argument("--game-domain", required=True)
+    resolve.add_argument("--public-mod-id", required=True)
+    resolve.add_argument("--file-name", required=True)
+    resolve.add_argument("--target-version", required=True)
+    resolve.add_argument("--github-output", type=Path, required=True)
+    resolve.set_defaults(handler=command_resolve)
+
+    verify = subparsers.add_parser("verify")
+    verify.add_argument("--game-domain", required=True)
+    verify.add_argument("--public-mod-id", required=True)
+    verify.add_argument("--file-name", required=True)
+    verify.add_argument("--file-id", required=True)
+    verify.add_argument("--target-version", required=True)
+    verify.add_argument("--nexus-url", required=True)
+    verify.add_argument("--timeout", type=int, default=600)
+    verify.add_argument("--interval", type=int, default=15)
+    verify.add_argument("--github-output", type=Path, required=True)
+    verify.set_defaults(handler=command_verify)
+
+    notes = subparsers.add_parser("notes")
+    notes.add_argument("--changes-file", type=Path, required=True)
+    notes.add_argument("--download-url", required=True)
+    notes.add_argument("--notes-file", type=Path, required=True)
+    notes.set_defaults(handler=command_notes)
+
+    update_json = subparsers.add_parser("update-json")
+    update_json.add_argument("--update-file", type=Path, default=Path("update.json"))
+    update_json.add_argument("--version", required=True)
+    update_json.add_argument("--download-url", required=True)
+    update_json.set_defaults(handler=command_update_json)
+    return parser
+
+
+def main() -> None:
+    """Run the requested release helper command."""
+
+    args = create_parser().parse_args()
+    try:
+        args.handler(args)
+    except ReleaseError as error:
+        print(f"error: {error}", file=sys.stderr)
+        raise SystemExit(1) from error
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/scripts/test_release_workflow.py
+++ b/tests/scripts/test_release_workflow.py
@@ -1,0 +1,195 @@
+"""Tests for the release workflow helpers."""
+
+import json
+from pathlib import Path
+
+import pytest
+from pytest_mock import MockerFixture
+
+from scripts.release_workflow import (
+    NexusClient,
+    ReleaseError,
+    create_release_notes,
+    direct_download_url,
+    extract_changelog,
+    load_project_metadata,
+    normalize_version,
+    update_update_json,
+)
+
+
+def test_load_project_metadata_validates_tag_and_nexus_url(tmp_path: Path) -> None:
+    """Project metadata is derived from one authoritative TOML file."""
+
+    project_file = tmp_path / "pyproject.toml"
+    project_file.write_text(
+        """
+[project]
+version = "3.2.2"
+description = "SSE Auto Translator"
+
+[project.urls]
+"Nexus Mods" = "https://www.nexusmods.com/skyrimspecialedition/mods/111491"
+""".strip(),
+        encoding="utf8",
+    )
+
+    metadata = load_project_metadata(project_file, "v3.2.2")
+
+    assert metadata.version == "3.2.2"
+    assert metadata.game_domain == "skyrimspecialedition"
+    assert metadata.public_mod_id == "111491"
+    assert metadata.archive_path == Path("dist/SSE Auto Translator_v3.2.2.zip")
+
+
+def test_load_project_metadata_rejects_mismatching_tag(tmp_path: Path) -> None:
+    """A release tag cannot differ from the project version."""
+
+    project_file = tmp_path / "pyproject.toml"
+    project_file.write_text(
+        """
+[project]
+version = "3.2.2"
+description = "SSE Auto Translator"
+
+[project.urls]
+"Nexus Mods" = "https://www.nexusmods.com/skyrimspecialedition/mods/111491"
+""".strip(),
+        encoding="utf8",
+    )
+
+    with pytest.raises(ReleaseError, match="does not match"):
+        load_project_metadata(project_file, "v3.2.3")
+
+
+def test_extract_changelog_accepts_annotated_heading(tmp_path: Path) -> None:
+    """Only the requested version section is included in release notes."""
+
+    changelog = tmp_path / "Changelog.md"
+    changelog.write_text(
+        "# v3.2.2 (Hotfix)\n\n- First\n- Second\n\n# v3.2.1\n\n- Old\n",
+        encoding="utf8",
+    )
+
+    assert extract_changelog(changelog, "v3.2.2") == "- First\n- Second"
+
+
+def test_release_notes_include_direct_nexus_link() -> None:
+    """GitHub notes point at the newly published Nexus file version."""
+
+    url = "https://www.nexusmods.com/game/mods/1?tab=files&file_id=42"
+
+    notes = create_release_notes("- Fixed", url)
+
+    assert notes == f"## Changes\n\n- Fixed\n\n## Download\n\n[{url}]({url})\n"
+
+
+def test_update_json_uses_version_without_v_prefix(tmp_path: Path) -> None:
+    """Application update metadata remains compatible with semantic-version."""
+
+    update_file = tmp_path / "update.json"
+    url = "https://www.nexusmods.com/game/mods/1?tab=files&file_id=42"
+
+    update_update_json(update_file, "v3.2.3", url)
+
+    assert json.loads(update_file.read_text(encoding="utf8")) == {
+        "version": "3.2.3",
+        "download_url": url,
+    }
+
+
+def test_latest_nexus_version_uses_update_chain_position() -> None:
+    """The latest Nexus version is selected by its decimal chain position."""
+
+    versions = [
+        {"version": "v2.0.0", "position": "2.0"},
+        {"version": "v10.0.0", "position": "10.0"},
+        {"version": "v3.0.0", "position": "3.0"},
+    ]
+
+    assert NexusClient.latest_version(versions)["version"] == "v10.0.0"
+
+
+def test_inspect_release_resolves_unique_active_named_file(
+    mocker: MockerFixture,
+) -> None:
+    """File resolution combines project name, active state and latest version."""
+
+    client = NexusClient("test-key")
+    mocker.patch.object(client, "get_mod_version", return_value="v3.2.2")
+    mocker.patch.object(client, "get_internal_mod_id", return_value="internal-mod")
+    mocker.patch.object(
+        client,
+        "get_mod_files",
+        return_value=[
+            {"id": "target", "name": "SSE Auto Translator", "is_active": True},
+            {"id": "old", "name": "SSE Auto Translator", "is_active": False},
+        ],
+    )
+    mocker.patch.object(
+        client,
+        "get_file_versions",
+        return_value=[
+            {
+                "version": "v3.2.2",
+                "position": "36",
+                "game_scoped_id": "786690",
+            }
+        ],
+    )
+
+    state = client.inspect_release(
+        "skyrimspecialedition", "111491", "SSE Auto Translator"
+    )
+
+    assert state.mod_version == "v3.2.2"
+    assert state.file.file_id == "target"
+    assert state.file.public_version_id == "786690"
+
+
+def test_direct_download_url_uses_public_file_id() -> None:
+    """The update URL uses the public game-scoped version ID."""
+
+    assert direct_download_url("https://www.nexusmods.com/game/mods/1", "42") == (
+        "https://www.nexusmods.com/game/mods/1?tab=files&file_id=42"
+    )
+
+
+def test_inspect_release_accepts_numeric_public_file_id(
+    mocker: MockerFixture,
+) -> None:
+    """Numeric Nexus IDs are normalized for use in the direct link."""
+
+    client = NexusClient("test-key")
+    mocker.patch.object(client, "get_mod_version", return_value="v3.2.2")
+    mocker.patch.object(client, "get_internal_mod_id", return_value="internal-mod")
+    mocker.patch.object(
+        client,
+        "get_mod_files",
+        return_value=[
+            {"id": "target", "name": "SSE Auto Translator", "is_active": True}
+        ],
+    )
+    mocker.patch.object(
+        client,
+        "get_file_versions",
+        return_value=[
+            {"version": "v3.2.2", "position": "36", "game_scoped_id": 786690}
+        ],
+    )
+
+    state = client.inspect_release(
+        "skyrimspecialedition", "111491", "SSE Auto Translator"
+    )
+
+    assert state.file.public_version_id == "786690"
+
+
+@pytest.mark.parametrize(
+    ("actual", "expected"),
+    [("v3.2.2", "3.2.2"), ("3.2.2", "3.2.2")],
+)
+def test_normalize_version(actual: str, expected: str) -> None:
+    """Version comparison accepts an optional leading v."""
+
+    assert normalize_version(actual) == expected

--- a/tests/scripts/test_release_workflow.py
+++ b/tests/scripts/test_release_workflow.py
@@ -1,6 +1,10 @@
 """Tests for the release workflow helpers."""
 
 import json
+import urllib.error
+from argparse import Namespace
+from email.message import Message
+from io import BytesIO
 from pathlib import Path
 
 import pytest
@@ -8,7 +12,12 @@ from pytest_mock import MockerFixture
 
 from scripts.release_workflow import (
     NexusClient,
+    NexusFileState,
+    NexusReleaseState,
     ReleaseError,
+    RetryableReleaseError,
+    command_resolve,
+    command_verify,
     create_release_notes,
     direct_download_url,
     extract_changelog,
@@ -98,6 +107,19 @@ def test_update_json_uses_version_without_v_prefix(tmp_path: Path) -> None:
     }
 
 
+def test_update_json_does_not_overwrite_newer_version(tmp_path: Path) -> None:
+    """A delayed older release cannot downgrade update metadata."""
+
+    update_file = tmp_path / "update.json"
+    current = {"version": "3.3.0", "download_url": "https://example.com/new"}
+    update_file.write_text(json.dumps(current), encoding="utf8")
+
+    changed = update_update_json(update_file, "v3.2.3", "https://example.com/old")
+
+    assert changed is False
+    assert json.loads(update_file.read_text(encoding="utf8")) == current
+
+
 def test_latest_nexus_version_uses_update_chain_position() -> None:
     """The latest Nexus version is selected by its decimal chain position."""
 
@@ -108,6 +130,59 @@ def test_latest_nexus_version_uses_update_chain_position() -> None:
     ]
 
     assert NexusClient.latest_version(versions)["version"] == "v10.0.0"
+
+
+@pytest.mark.parametrize("status", [429, 500, 503])
+def test_nexus_client_classifies_transient_http_errors(
+    status: int, mocker: MockerFixture
+) -> None:
+    """Rate limits and server failures can be retried during verification."""
+
+    error = urllib.error.HTTPError(
+        "https://api.nexusmods.com/test",
+        status,
+        "temporary failure",
+        hdrs=Message(),
+        fp=BytesIO(b"temporary failure"),
+    )
+    mocker.patch("scripts.release_workflow.urllib.request.urlopen", side_effect=error)
+
+    with pytest.raises(RetryableReleaseError):
+        NexusClient("test-key").get_mod_version("game", "1")
+
+
+def test_nexus_client_classifies_network_error_as_transient(
+    mocker: MockerFixture,
+) -> None:
+    """Network failures can be retried during verification."""
+
+    mocker.patch(
+        "scripts.release_workflow.urllib.request.urlopen",
+        side_effect=urllib.error.URLError("connection reset"),
+    )
+
+    with pytest.raises(RetryableReleaseError):
+        NexusClient("test-key").get_mod_version("game", "1")
+
+
+def test_nexus_client_keeps_permanent_http_error_non_retryable(
+    mocker: MockerFixture,
+) -> None:
+    """Authentication and other permanent failures still abort immediately."""
+
+    error = urllib.error.HTTPError(
+        "https://api.nexusmods.com/test",
+        401,
+        "unauthorized",
+        hdrs=Message(),
+        fp=BytesIO(b"unauthorized"),
+    )
+    mocker.patch("scripts.release_workflow.urllib.request.urlopen", side_effect=error)
+
+    with pytest.raises(ReleaseError) as raised:
+        NexusClient("test-key").get_mod_version("game", "1")
+
+    assert not isinstance(raised.value, RetryableReleaseError)
 
 
 def test_inspect_release_resolves_unique_active_named_file(
@@ -183,6 +258,88 @@ def test_inspect_release_accepts_numeric_public_file_id(
     )
 
     assert state.file.public_version_id == "786690"
+
+
+def test_resolve_treats_target_file_with_stale_mod_page_as_rerun(
+    tmp_path: Path,
+    mocker: MockerFixture,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A propagated file version prevents a duplicate upload on rerun."""
+
+    output = tmp_path / "output.txt"
+    monkeypatch.setenv("NEXUSMODS_API_KEY", "test-key")
+    mocker.patch.object(
+        NexusClient,
+        "inspect_release",
+        return_value=NexusReleaseState(
+            mod_version="v3.2.2",
+            file=NexusFileState(
+                file_id="target",
+                name="SSE Auto Translator",
+                version="v3.2.3",
+                public_version_id="42",
+            ),
+        ),
+    )
+
+    command_resolve(
+        Namespace(
+            game_domain="skyrimspecialedition",
+            public_mod_id="111491",
+            file_name="SSE Auto Translator",
+            target_version="v3.2.3",
+            github_output=output,
+        )
+    )
+
+    assert "already_published=true" in output.read_text(encoding="utf8")
+
+
+def test_verify_retries_transient_failure_then_succeeds(
+    tmp_path: Path,
+    mocker: MockerFixture,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Temporary Nexus failures do not abort propagation polling."""
+
+    output = tmp_path / "output.txt"
+    monkeypatch.setenv("NEXUSMODS_API_KEY", "test-key")
+    inspect_release = mocker.patch.object(
+        NexusClient,
+        "inspect_release",
+        side_effect=[
+            RetryableReleaseError("temporarily unavailable"),
+            NexusReleaseState(
+                mod_version="v3.2.3",
+                file=NexusFileState(
+                    file_id="target",
+                    name="SSE Auto Translator",
+                    version="v3.2.3",
+                    public_version_id="43",
+                ),
+            ),
+        ],
+    )
+    sleep = mocker.patch("scripts.release_workflow.time.sleep")
+
+    command_verify(
+        Namespace(
+            game_domain="skyrimspecialedition",
+            public_mod_id="111491",
+            file_name="SSE Auto Translator",
+            file_id="target",
+            target_version="v3.2.3",
+            nexus_url="https://www.nexusmods.com/skyrimspecialedition/mods/111491",
+            timeout=10,
+            interval=1,
+            github_output=output,
+        )
+    )
+
+    assert inspect_release.call_count == 2
+    sleep.assert_called_once_with(1)
+    assert "public_file_id=43" in output.read_text(encoding="utf8").splitlines()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- validate `v*` tags against `pyproject.toml` and build through `build.bat`
- publish and verify the Nexus file before creating the GitHub Release
- use the new Nexus `file_id` in release notes and `update.json`
- keep reruns safe when the Nexus version already exists

## Validation

- 11 release workflow tests passed
- Ruff and Pyright passed
- workflow YAML parsed successfully

Closes #153

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an automated Windows release workflow triggered by version tags.
  * Releases now validate metadata, build and verify archives, publish files to Nexus Mods, generate release notes, and update application information.
  * Added release tooling for preparing, resolving, verifying, and finalizing releases.
  * Added a Nexus Mods project link to project metadata.

* **Bug Fixes**
  * Improved release retries, rerun handling, version comparisons, and protection against downgrading update information.

* **Tests**
  * Added comprehensive coverage for release validation, version handling, changelog extraction, download links, retries, and update metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->