### PR TITLE
SSE-AT does not find any translations anymore

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,5 @@
 # v3.2.3
 
-- Fix translation discovery after Nexus Mods changed the translations table
 - Fix SSE-AT not finding translations that were uploaded after the introduction of the new upload system
 
 # v3.2.2

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,6 @@
 # v3.2.3
 
+- Fix translation discovery after Nexus Mods changed the translations table
 - Fix SSE-AT not finding translations that were uploaded after the introduction of the new upload system
 
 # v3.2.2

--- a/src/core/translation_provider/nm_api/nm_api.py
+++ b/src/core/translation_provider/nm_api/nm_api.py
@@ -7,6 +7,7 @@ Attribution-NonCommercial-NoDerivatives 4.0 International.
 import re
 import webbrowser
 from concurrent.futures import Future, ThreadPoolExecutor, as_completed
+from pathlib import Path
 from queue import Queue
 from typing import Any, Optional, TypeVar, override
 from uuid import uuid4
@@ -58,6 +59,7 @@ class NexusModsApi(ProviderApi):
 
     LANG_OVERRIDES: dict[str, str] = {
         "Mandarin": "Chinese",
+        "Simplified Chinese": "Chinese",
     }
     """Map for languages that are named differently on the Nexus Mods site."""
 
@@ -607,7 +609,9 @@ class NexusModsApi(ProviderApi):
             raise ProviderApi.raise_mod_not_found_error(NxmModId(mod_id=mod_id))
 
         url: str = f"https://www.nexusmods.com/{game_id}/mods/{mod_id}"
-        cache_file_path = ProviderApi.CACHE_FOLDER / (get_url_identifier(url) + ".cache")
+        cache_file_path: Path = ProviderApi.CACHE_FOLDER / (
+            f"translations-table-v1-{get_url_identifier(url)}.cache"
+        )
 
         cached: Optional[req.Response | curl_requests.Response] = Cache.get_from_cache(
             cache_file_path, default=None
@@ -632,29 +636,32 @@ class NexusModsApi(ProviderApi):
         html: str = res.content.decode(errors="replace")
         parsed = bs4.BeautifulSoup(html, features="html.parser")
 
-        translation_list: Optional[bs4.Tag] = parsed.find(
-            "ul", {"class": "translations"}
-        )
-        if translation_list is None:
-            return []
-
+        language_aliases: dict[str, str] = {
+            name.casefold(): alias.casefold()
+            for name, alias in NexusModsApi.LANG_OVERRIDES.items()
+        }
+        requested_language: str = language.strip().casefold()
         available_translations: list[int] = []
-        for tag in translation_list.children:
-            tag_text: Optional[str] = tag.text
-
-            if not tag_text or tag_text == "\n":
+        seen_ids: set[int] = set()
+        for tag in parsed.select(
+            "table.translation-table tbody td.table-translation-name a"
+        ):
+            lang_name: str = " ".join(tag.get_text(" ", strip=True).split()).casefold()
+            lang_name = language_aliases.get(lang_name, lang_name)
+            if lang_name != requested_language:
                 continue
 
-            tags: bs4.ResultSet[bs4.Tag] = parsed.find_all(
-                "a", {"class": f"sortme flag flag-{tag_text}"}
-            )
-            urls: list[str] = [tag["href"] for tag in tags]  # type: ignore[misc,index]
-
-            lang_name: str = NexusModsApi.LANG_OVERRIDES.get(tag_text, tag_text).lower()
-            if lang_name == language:
-                available_translations += [
-                    NexusModsApi.get_ids_from_url(url)[1] for url in urls
-                ]
+            href = tag.get("href")
+            if not isinstance(href, str):
+                continue
+            try:
+                linked_game_id, translation_id, _ = NexusModsApi.get_ids_from_url(href)
+            except ValueError:
+                continue
+            if linked_game_id != game_id or translation_id in seen_ids:
+                continue
+            available_translations.append(translation_id)
+            seen_ids.add(translation_id)
 
         return available_translations
 

--- a/src/core/translation_provider/nm_api/nm_api.py
+++ b/src/core/translation_provider/nm_api/nm_api.py
@@ -10,6 +10,7 @@ from concurrent.futures import Future, ThreadPoolExecutor, as_completed
 from pathlib import Path
 from queue import Queue
 from typing import Any, Optional, TypeVar, override
+from urllib.parse import urljoin
 from uuid import uuid4
 
 import bs4
@@ -60,6 +61,8 @@ class NexusModsApi(ProviderApi):
     LANG_OVERRIDES: dict[str, str] = {
         "Mandarin": "Chinese",
         "Simplified Chinese": "Chinese",
+        "Portuguese (Brazil)": "Portuguese",
+        "Spanish (Spain)": "Spanish",
     }
     """Map for languages that are named differently on the Nexus Mods site."""
 
@@ -609,9 +612,7 @@ class NexusModsApi(ProviderApi):
             raise ProviderApi.raise_mod_not_found_error(NxmModId(mod_id=mod_id))
 
         url: str = f"https://www.nexusmods.com/{game_id}/mods/{mod_id}"
-        cache_file_path: Path = ProviderApi.CACHE_FOLDER / (
-            f"translations-table-v1-{get_url_identifier(url)}.cache"
-        )
+        cache_file_path: Path = ProviderApi.CACHE_FOLDER / (get_url_identifier(url) + ".cache")
 
         cached: Optional[req.Response | curl_requests.Response] = Cache.get_from_cache(
             cache_file_path, default=None
@@ -643,19 +644,21 @@ class NexusModsApi(ProviderApi):
         requested_language: str = language.strip().casefold()
         available_translations: list[int] = []
         seen_ids: set[int] = set()
-        for tag in parsed.select(
-            "table.translation-table tbody td.table-translation-name a"
-        ):
+        for tag in parsed.select("table.translation-table td.table-translation-name a"):
             lang_name: str = " ".join(tag.get_text(" ", strip=True).split()).casefold()
             lang_name = language_aliases.get(lang_name, lang_name)
             if lang_name != requested_language:
                 continue
 
             href = tag.get("href")
-            if not isinstance(href, str):
+            if not isinstance(href, str) or not href.strip():
+                continue
+            if href.lstrip().startswith(("#", "?")):
                 continue
             try:
-                linked_game_id, translation_id, _ = NexusModsApi.get_ids_from_url(href)
+                linked_game_id, translation_id, _ = NexusModsApi.get_ids_from_url(
+                    urljoin(url, href.strip())
+                )
             except ValueError:
                 continue
             if linked_game_id != game_id or translation_id in seen_ids:

--- a/tests/core/translation_provider/nm_api/test_nm_api.py
+++ b/tests/core/translation_provider/nm_api/test_nm_api.py
@@ -165,6 +165,11 @@ class TestNexusModsApi(CoreTest):
             (" \n RuSSian \n ", " RUSSIAN ", [42, 43]),
             ("Mandarin", "chinese", [42, 43]),
             ("simplified\n Chinese", "chinese", [42, 43]),
+            ("Portuguese (Brazil)", "portuguese", [42, 43]),
+            ("Spanish (Spain)", "spanish", [42, 43]),
+            ("Portuguese", "portuguese", [42, 43]),
+            ("Spanish", "spanish", [42, 43]),
+            ("Portuguese (Portugal)", "portuguese", []),
             ("Traditional Chinese", "chinese", []),
         ],
     )
@@ -244,9 +249,61 @@ class TestNexusModsApi(CoreTest):
         # then
         assert actual == []
 
-    def test_scrape_ignores_legacy_cache(self, mocker: MockerFixture) -> None:
+    @pytest.mark.parametrize("with_tbody", [True, False])
+    @pytest.mark.parametrize(
+        ("href", "expected"),
+        [
+            ("https://www.nexusmods.com/skyrimspecialedition/mods/42", [42]),
+            ("/skyrimspecialedition/mods/42", [42]),
+            ("42", [42]),
+            ("//www.nexusmods.com/skyrimspecialedition/mods/42", [42]),
+            ("https://example.com/skyrimspecialedition/mods/42", []),
+            ("/skyrim/mods/42", []),
+            ("", []),
+            (" ", []),
+            ("#translations", []),
+            ("?tab=description", []),
+            ("https://[invalid", []),
+        ],
+    )
+    def test_scrape_optional_tbody_and_relative_links(
+        self,
+        mocker: MockerFixture,
+        with_tbody: bool,
+        href: str,
+        expected: list[int],
+    ) -> None:
         """
-        Tests that legacy cached HTML cannot hide newly available translations.
+        Tests equivalent table markup and safe resolution of relative links.
+
+        Args:
+            mocker (MockerFixture): Mocking fixture.
+            with_tbody (bool): Whether the table contains an explicit body.
+            href (str): Link target in the translation cell.
+            expected (list[int]): Expected matching translation IDs.
+        """
+
+        # given
+        rows: str = (
+            '<tr><td class="table-translation-name">'
+            f'<a href="{href}">Russian</a></td></tr>'
+        )
+        if with_tbody:
+            rows = f"<tbody>{rows}</tbody>"
+        html: str = f'<table class="translation-table">{rows}</table>'
+        mocker.patch.object(
+            Cache, "get_from_cache", return_value=Mock(content=html.encode())
+        )
+
+        # when
+        actual: list[int] = self.__scrape(NexusModsApi(), "russian")
+
+        # then
+        assert actual == expected
+
+    def test_scrape_reuses_existing_cache_key(self, mocker: MockerFixture) -> None:
+        """
+        Tests that fetched pages are saved and reused with the existing cache key.
 
         Args:
             mocker (MockerFixture): Mocking fixture.
@@ -255,11 +312,8 @@ class TestNexusModsApi(CoreTest):
         # given
         url: str = "https://www.nexusmods.com/skyrimspecialedition/mods/123"
         identifier: str = get_url_identifier(url)
-        old_path: Path = ProviderApi.CACHE_FOLDER / f"{identifier}.cache"
-        new_path: Path = ProviderApi.CACHE_FOLDER / (
-            f"translations-table-v1-{identifier}.cache"
-        )
-        cached: dict[Path, Mock] = {old_path: Mock(content=b"legacy page")}
+        cache_path: Path = ProviderApi.CACHE_FOLDER / f"{identifier}.cache"
+        cached: dict[Path, Mock] = {}
 
         def get_cached(path: Path, default: Optional[Mock]) -> Optional[Mock]:
             """
@@ -287,19 +341,19 @@ class TestNexusModsApi(CoreTest):
         self.__scrape(NexusModsApi(), "russian")
 
         # then
-        read_cache.assert_called_once_with(new_path, default=None)
+        read_cache.assert_called_once_with(cache_path, default=None)
         session.return_value.get.assert_called_once()
-        save_cache.assert_called_once_with(new_path, response)
+        save_cache.assert_called_once_with(cache_path, response)
 
         # given
-        cached[new_path] = response
+        cached[cache_path] = response
         read_cache.reset_mock()
 
         # when
         self.__scrape(NexusModsApi(), "russian")
 
         # then
-        read_cache.assert_called_once_with(new_path, default=None)
+        read_cache.assert_called_once_with(cache_path, default=None)
         session.assert_called_once()
         session.return_value.get.assert_called_once()
         save_cache.assert_called_once()

--- a/tests/core/translation_provider/nm_api/test_nm_api.py
+++ b/tests/core/translation_provider/nm_api/test_nm_api.py
@@ -2,11 +2,20 @@
 Copyright (c) Cutleast
 """
 
+from collections.abc import Callable
+from pathlib import Path
+from typing import Optional, cast
+from unittest.mock import Mock
+
 import pytest
+from cutleast_core_lib.core.cache.cache import Cache
 from cutleast_core_lib.core.utilities.datetime import to_timestamp
 from cutleast_core_lib.test.utils import Utils
+from pytest_mock import MockerFixture
 
+from core.translation_provider.provider_api import ProviderApi
 from core.translation_provider.provider_manager import NexusModsApi
+from core.utilities.web_utils import get_url_identifier
 from tests.core.core_test import CoreTest
 
 
@@ -76,3 +85,251 @@ class TestNexusModsApi(CoreTest):
 
         # then
         assert actual_result == expected_output
+
+    @staticmethod
+    def __scrape(api: NexusModsApi, language: str) -> list[int]:
+        """
+        Calls the private scraper using the public method's language convention.
+
+        Args:
+            api (NexusModsApi): Provider under test.
+            language (str): Requested language.
+
+        Returns:
+            list[int]: Matching translation IDs.
+        """
+
+        method_name: str = f"_{NexusModsApi.__name__}__scrape_mod_translations"
+        method = cast(
+            Callable[[str, int, str], list[int]],
+            getattr(api, method_name),
+        )
+        return method("skyrimspecialedition", 123, language)
+
+    @pytest.mark.parametrize(
+        ("language", "expected"),
+        [("russian", [191078]), ("Chinese", [190664]), ("german", [])],
+    )
+    def test_scrape_issue_table(
+        self, mocker: MockerFixture, language: str, expected: list[int]
+    ) -> None:
+        """
+        Tests the translation table structure reported in issue 158.
+
+        Args:
+            mocker (MockerFixture): Mocking fixture.
+            language (str): Requested language.
+            expected (list[int]): Expected translation IDs.
+        """
+
+        # given
+        html: str = """
+        <dd class="clearfix open"><div class="tabbed-block">
+          <h3>Translations available on the Nexus</h3>
+          <table class="table translation-table"><tbody>
+            <tr><td class="table-translation-name">
+              <a class="sortme flag flag-ru"
+                 href="https://www.nexusmods.com/skyrimspecialedition/mods/191078">
+                Russian
+              </a><span class="table-author-name">Author: Apokrif Znaniy</span>
+            </td><td class="table-translation-notes">
+              <span class="sortme">King of the Murkmire Russian Translation</span>
+            </td></tr>
+            <tr><td class="table-translation-name">
+              <a class="sortme flag flag-cn"
+                 href="https://www.nexusmods.com/skyrimspecialedition/mods/190664">
+                Simplified Chinese
+              </a><span class="table-author-name">Author: DantyAcent</span>
+            </td></tr>
+          </tbody></table>
+        </div></dd>
+        """
+        mocker.patch.object(
+            Cache, "get_from_cache", return_value=Mock(content=html.encode())
+        )
+        session = mocker.patch(
+            "core.translation_provider.nm_api.nm_api.curl_requests.Session"
+        )
+        api = NexusModsApi()
+
+        # when
+        actual: list[int] = self.__scrape(api, language)
+
+        # then
+        assert actual == expected
+        session.assert_not_called()
+
+    @pytest.mark.parametrize(
+        ("label", "language", "expected"),
+        [
+            (" \n RuSSian \n ", " RUSSIAN ", [42, 43]),
+            ("Mandarin", "chinese", [42, 43]),
+            ("simplified\n Chinese", "chinese", [42, 43]),
+            ("Traditional Chinese", "chinese", []),
+        ],
+    )
+    def test_scrape_filters_links(
+        self,
+        mocker: MockerFixture,
+        label: str,
+        language: str,
+        expected: list[int],
+    ) -> None:
+        """
+        Tests normalization, table scoping, URL validation and stable deduplication.
+
+        Args:
+            mocker (MockerFixture): Mocking fixture.
+            label (str): Language label in the HTML.
+            language (str): Requested language.
+            expected (list[int]): Expected unique IDs in table order.
+        """
+
+        # given
+        base: str = "https://www.nexusmods.com/skyrimspecialedition/mods/"
+        links: str = "".join(
+            f'<a class="extra flag-ru flag sortme" href="{url}">{label}</a>'
+            for url in [
+                base + "42",
+                base + "42",
+                "invalid",
+                "https://www.nexusmods.com/skyrim/mods/99",
+                base + "43",
+            ]
+        )
+        html: str = (
+            f'<a class="sortme flag flag-ru" href="{base}88">{label}</a>'
+            '<table class="extra translation-table table"><tbody><tr>'
+            f'<td class="extra table-translation-name">{links}'
+            f'<a>{label}</a></td><td class="table-translation-notes">'
+            f'<a href="{base}77">{label}</a></td></tr></tbody></table>'
+        )
+        mocker.patch.object(
+            Cache, "get_from_cache", return_value=Mock(content=html.encode())
+        )
+
+        # when
+        actual: list[int] = self.__scrape(NexusModsApi(), language)
+
+        # then
+        assert actual == expected
+
+    @pytest.mark.parametrize(
+        "html",
+        [
+            "<html></html>",
+            '<table class="translation-table"><tbody></tbody></table>',
+            '<ul class="translations"><li>Russian</li></ul>',
+        ],
+    )
+    def test_scrape_missing_table_entries(
+        self, mocker: MockerFixture, html: str
+    ) -> None:
+        """
+        Tests pages without usable new-format translations.
+
+        Args:
+            mocker (MockerFixture): Mocking fixture.
+            html (str): Page without translation entries.
+        """
+
+        # given
+        mocker.patch.object(
+            Cache, "get_from_cache", return_value=Mock(content=html.encode())
+        )
+
+        # when
+        actual: list[int] = self.__scrape(NexusModsApi(), "russian")
+
+        # then
+        assert actual == []
+
+    def test_scrape_ignores_legacy_cache(self, mocker: MockerFixture) -> None:
+        """
+        Tests that legacy cached HTML cannot hide newly available translations.
+
+        Args:
+            mocker (MockerFixture): Mocking fixture.
+        """
+
+        # given
+        url: str = "https://www.nexusmods.com/skyrimspecialedition/mods/123"
+        identifier: str = get_url_identifier(url)
+        old_path: Path = ProviderApi.CACHE_FOLDER / f"{identifier}.cache"
+        new_path: Path = ProviderApi.CACHE_FOLDER / (
+            f"translations-table-v1-{identifier}.cache"
+        )
+        cached: dict[Path, Mock] = {old_path: Mock(content=b"legacy page")}
+
+        def get_cached(path: Path, default: Optional[Mock]) -> Optional[Mock]:
+            """
+            Looks up a response in the simulated cache.
+
+            Args:
+                path (Path): Cache key requested by the scraper.
+                default (Optional[Mock]): Fallback for a missing entry.
+
+            Returns:
+                Optional[Mock]: Cached response or fallback.
+            """
+
+            return cached.get(path, default)
+
+        read_cache = mocker.patch.object(Cache, "get_from_cache", side_effect=get_cached)
+        save_cache = mocker.patch.object(Cache, "save_to_cache")
+        response = Mock(status_code=200, content=b"<html></html>")
+        session = mocker.patch(
+            "core.translation_provider.nm_api.nm_api.curl_requests.Session"
+        )
+        session.return_value.get.return_value = response
+
+        # when
+        self.__scrape(NexusModsApi(), "russian")
+
+        # then
+        read_cache.assert_called_once_with(new_path, default=None)
+        session.return_value.get.assert_called_once()
+        save_cache.assert_called_once_with(new_path, response)
+
+        # given
+        cached[new_path] = response
+        read_cache.reset_mock()
+
+        # when
+        self.__scrape(NexusModsApi(), "russian")
+
+        # then
+        read_cache.assert_called_once_with(new_path, default=None)
+        session.assert_called_once()
+        session.return_value.get.assert_called_once()
+        save_cache.assert_called_once()
+
+    def test_scrape_preserves_http_errors(self, mocker: MockerFixture) -> None:
+        """
+        Tests that HTTP errors reach the existing handler before caching or parsing.
+
+        Args:
+            mocker (MockerFixture): Mocking fixture.
+        """
+
+        # given
+        mocker.patch.object(Cache, "get_from_cache", return_value=None)
+        save_cache = mocker.patch.object(Cache, "save_to_cache")
+        session = mocker.patch(
+            "core.translation_provider.nm_api.nm_api.curl_requests.Session"
+        )
+        session.return_value.get.return_value = Mock(status_code=503)
+        api = NexusModsApi()
+        handler = mocker.patch.object(
+            api, "handle_status_code", side_effect=RuntimeError("HTTP failure")
+        )
+
+        # when
+        with pytest.raises(RuntimeError, match="HTTP failure"):
+            self.__scrape(api, "russian")
+
+        # then
+        handler.assert_called_once_with(
+            "https://www.nexusmods.com/skyrimspecialedition/mods/123", 503
+        )
+        save_cache.assert_not_called()


### PR DESCRIPTION
Nexus Mods replaced the translation language list with a table, causing translation discovery to return no results. Read translation links and language labels from the new table, including tables without an explicit tbody and relative links. Normalize language labels, retain table order, and skip duplicates, invalid links and links to other games.

Map Simplified Chinese to Chinese, Portuguese (Brazil) to Portuguese, and Spanish (Spain) to Spanish alongside the existing Mandarin alias. These labels appear in the current USSEP translation table: https://www.nexusmods.com/skyrimspecialedition/mods/266. The mappings match the project's zh_CN, pt_BR and es_ES language settings; Traditional Chinese and Portuguese (Portugal) are not automatically mapped to other regions.

Keep the existing cache key: the application already invalidates its cache on version upgrades. No changelog, release version, dependency or submodule changes.

Validation performed locally: all 56 translation-provider tests pass with mocked network responses, including the original issue example, language filtering, optional tbody, relative links, invalid URLs, cache reuse and HTTP error propagation. Ruff and Pyright pass for both changed Python files. No live end-to-end Nexus scan was performed.

Closes #158
